### PR TITLE
Add unified Deploy-SecurityBaselines.ps1 and rewrite README

### DIFF
--- a/Deploy-SecurityBaselines.ps1
+++ b/Deploy-SecurityBaselines.ps1
@@ -1,0 +1,364 @@
+<#
+.SYNOPSIS
+  Deploys Intune Security Baseline policies from the Security-Baselines GitHub repository.
+
+.DESCRIPTION
+    Downloads the Security-Baselines repository from GitHub, extracts the selected
+    baseline JSON files (Windows 24H2, Edge v128, M365), and creates Intune device
+    management configuration policies for each one. Existing policies with the same
+    name are skipped. Optionally assigns all created policies to an Entra ID security group.
+
+    Temporary files are automatically cleaned up after deployment.
+
+.PARAMETER InstallWindows
+    Deploy Windows 11 v24H2 Security Baseline policies (28 policies).
+
+.PARAMETER InstallEdge
+    Deploy Microsoft Edge v128 Security Baseline policies (7 policies).
+
+.PARAMETER InstallM365
+    Deploy Microsoft 365 Apps Security Baseline policies (12 policies).
+
+.PARAMETER InstallAll
+    Deploy all available Security Baseline policies (Windows, Edge, and M365).
+
+.PARAMETER GroupAssignmentId
+    The Object ID of an Entra ID security group. If specified, all created policies
+    will be assigned to this group.
+
+.OUTPUTS
+  Status messages on screen.
+  Log file at "$env:TEMP\Deploy-SecurityBaselines.log"
+
+.NOTES
+  Version:        1.0.0
+  Author:         Dustin Gullett / Thiago Beier
+  Creation Date:  03/17/2026
+  Purpose/Change: Unified deployment script for all security baselines.
+
+.EXAMPLE
+  .\Deploy-SecurityBaselines.ps1 -InstallAll
+  Deploys all baselines (Windows, Edge, and M365).
+
+.EXAMPLE
+  .\Deploy-SecurityBaselines.ps1 -InstallWindows -InstallEdge
+  Deploys only Windows and Edge baselines.
+
+.EXAMPLE
+  .\Deploy-SecurityBaselines.ps1 -InstallAll -GroupAssignmentId "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+  Deploys all baselines and assigns them to the specified Entra ID group.
+
+.EXAMPLE
+  .\Deploy-SecurityBaselines.ps1 -InstallM365 -GroupAssignmentId "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+  Deploys only M365 baselines and assigns them to the specified group.
+#>
+[CmdletBinding()]
+param (
+  [switch]$InstallWindows,
+  [switch]$InstallEdge,
+  [switch]$InstallM365,
+  [switch]$InstallAll,
+
+  [Parameter(HelpMessage = "Entra ID security group Object ID to assign created policies to.")]
+  [string]$GroupAssignmentId
+)
+
+# ── Validate parameters ─────────────────────────────────────────────────────
+if (-not ($InstallWindows -or $InstallEdge -or $InstallM365 -or $InstallAll)) {
+  Write-Host ""
+  Write-Host "ERROR: You must specify at least one baseline to install." -ForegroundColor Red
+  Write-Host ""
+  Write-Host "Usage examples:" -ForegroundColor Yellow
+  Write-Host "  .\Deploy-SecurityBaselines.ps1 -InstallAll" -ForegroundColor White
+  Write-Host "  .\Deploy-SecurityBaselines.ps1 -InstallWindows" -ForegroundColor White
+  Write-Host "  .\Deploy-SecurityBaselines.ps1 -InstallWindows -InstallEdge" -ForegroundColor White
+  Write-Host "  .\Deploy-SecurityBaselines.ps1 -InstallAll -GroupAssignmentId 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx'" -ForegroundColor White
+  Write-Host ""
+  exit 1
+}
+
+if ($InstallAll) {
+  $InstallWindows = $true
+  $InstallEdge    = $true
+  $InstallM365    = $true
+}
+
+# ── Logging ──────────────────────────────────────────────────────────────────
+$logFilePath = "$env:TEMP\Deploy-SecurityBaselines.log"
+
+function Write-Log {
+  param (
+    [string]$Message,
+    [string]$Color = "White"
+  )
+  Write-Host $Message -ForegroundColor $Color
+  try {
+    Add-Content -Path $logFilePath -Value "$(Get-Date -Format 'yyyy-MM-dd HH:mm:ss') - $Message" -ErrorAction Stop
+  }
+  catch {
+    Write-Warning "Unable to write to log file: $logFilePath"
+  }
+}
+
+# ── Display settings ────────────────────────────────────────────────────────
+Write-Host ""
+Write-Host "============================================================" -ForegroundColor Cyan
+Write-Host "  Security Baselines - Intune Policy Deployment              " -ForegroundColor Cyan
+Write-Host "============================================================" -ForegroundColor Cyan
+Write-Host ""
+
+$selectedBaselines = @()
+if ($InstallWindows) { $selectedBaselines += "Windows 11 v24H2" }
+if ($InstallEdge)    { $selectedBaselines += "Microsoft Edge v128" }
+if ($InstallM365)    { $selectedBaselines += "Microsoft 365 Apps" }
+
+Write-Log "  Baselines selected : $($selectedBaselines -join ', ')" "Yellow"
+
+if ($GroupAssignmentId) {
+  Write-Log "  Group assignment   : $GroupAssignmentId" "Yellow"
+}
+else {
+  Write-Log "  Group assignment   : None (policies will be unassigned)" "Yellow"
+}
+
+Write-Host ""
+
+$proceed = Read-Host "Continue with these settings? (Y/N)"
+if ($proceed -notin @('Y', 'y')) {
+  Write-Log "Script aborted by user." "Red"
+  exit
+}
+
+# ── Step 1 - Download and extract ────────────────────────────────────────────
+Write-Log "Step 1: Download and extract baseline archive" "Cyan"
+
+$fileUrl     = "https://github.com/dgulle/Security-Baselines/archive/refs/heads/master.zip"
+$tempFolder  = Join-Path $env:TEMP "SecurityBaselines_$(Get-Date -Format 'yyyyMMdd_HHmmss')"
+$destinationZip = Join-Path $tempFolder "master.zip"
+
+New-Item -Path $tempFolder -ItemType Directory -Force | Out-Null
+
+try {
+  Write-Log "  Downloading repository archive..." "Cyan"
+  Invoke-WebRequest -Uri $fileUrl -OutFile $destinationZip -UseBasicParsing -ErrorAction Stop
+  Write-Log "  Download complete." "Green"
+}
+catch {
+  Write-Log "  ERROR: Failed to download - $_" "Red"
+  exit 1
+}
+
+try {
+  Write-Log "  Extracting archive..." "Cyan"
+  Expand-Archive -Path $destinationZip -DestinationPath $tempFolder -Force -ErrorAction Stop
+  Write-Log "  Extraction complete." "Green"
+}
+catch {
+  Write-Log "  ERROR: Failed to extract - $_" "Red"
+  exit 1
+}
+
+$repoRoot = Join-Path $tempFolder "Security-Baselines-master"
+
+# ── Step 2 - Microsoft Graph module ──────────────────────────────────────────
+Write-Log "Step 2: Verify Microsoft.Graph.Beta module" "Cyan"
+
+$moduleName = "Microsoft.Graph.Beta"
+$module = Get-InstalledModule -Name $moduleName -ErrorAction SilentlyContinue
+
+if (-not $module) {
+  Write-Log "  $moduleName is not installed. Installing for current user..." "Yellow"
+  try {
+    Install-Module -Name $moduleName -Scope CurrentUser -Force -AllowClobber -ErrorAction Stop
+    Write-Log "  $moduleName installed successfully." "Green"
+  }
+  catch {
+    Write-Log "  ERROR: Failed to install $moduleName - $_" "Red"
+    exit 1
+  }
+}
+else {
+  Write-Log "  $moduleName is already installed." "Green"
+}
+
+try {
+  # Remove any previously loaded Microsoft.Graph modules to avoid assembly version conflicts
+  Write-Log "  Removing any previously loaded Microsoft.Graph modules..." "Cyan"
+  Get-Module Microsoft.Graph* | Remove-Module -Force -ErrorAction SilentlyContinue
+
+  # Clean up duplicate Microsoft.Graph.Authentication versions that cause assembly conflicts
+  $authVersions = Get-Module -Name Microsoft.Graph.Authentication -ListAvailable
+  if ($authVersions.Count -gt 1) {
+    Write-Log "  Multiple versions of Microsoft.Graph.Authentication detected. Cleaning up old versions..." "Yellow"
+    $latest = $authVersions | Sort-Object Version -Descending | Select-Object -First 1
+    foreach ($oldVersion in ($authVersions | Where-Object { $_.Version -ne $latest.Version })) {
+      try {
+        Uninstall-Module -Name Microsoft.Graph.Authentication -RequiredVersion $oldVersion.Version -Force -ErrorAction SilentlyContinue
+        Write-Log "    Removed Microsoft.Graph.Authentication v$($oldVersion.Version)" "Yellow"
+      }
+      catch {
+        Write-Log "    Could not remove Microsoft.Graph.Authentication v$($oldVersion.Version) - $_" "Yellow"
+      }
+    }
+  }
+
+  # Import Authentication module first so the correct version is loaded before dependent modules
+  Write-Log "  Importing Microsoft.Graph.Authentication..." "Cyan"
+  Import-Module Microsoft.Graph.Authentication -Force -ErrorAction Stop
+
+  Write-Log "  Importing Microsoft.Graph.Beta.DeviceManagement..." "Cyan"
+  Import-Module Microsoft.Graph.Beta.DeviceManagement -Force -ErrorAction Stop
+
+  Write-Log "  Connecting to Microsoft Graph..." "Cyan"
+  $scopes = @(
+    "DeviceManagementConfiguration.Read.All",
+    "DeviceManagementConfiguration.ReadWrite.All"
+  )
+  if ($GroupAssignmentId) {
+    $scopes += "Group.Read.All"
+  }
+  Connect-MgGraph -Scopes $scopes -ErrorAction Stop
+}
+catch {
+  Write-Log "  ERROR: Failed to import module or connect to Microsoft Graph - $_" "Red"
+  Write-Log "  TIP: Try running 'Uninstall-Module Microsoft.Graph -AllVersions -Force' and 'Update-Module Microsoft.Graph.Beta -Force', then re-run in a new PowerShell session." "Yellow"
+  exit 1
+}
+
+# ── Helper function - Deploy baseline policies ──────────────────────────────
+function Deploy-BaselinePolicies {
+  param (
+    [string]$BaselineName,
+    [string]$JsonPath,
+    [string]$GroupId
+  )
+
+  Write-Log ""
+  Write-Log "  -- $BaselineName --" "Cyan"
+
+  if (-not (Test-Path -Path $JsonPath)) {
+    Write-Log "    ERROR: Path not found - $JsonPath" "Red"
+    return @{ Created = 0; Skipped = 0; Failed = 0 }
+  }
+
+  # Get JSON files from the root of the baseline directory only (not subdirectories)
+  $jsonFiles = Get-ChildItem -Path $JsonPath -Filter *.json -File
+  Write-Log "    Found $($jsonFiles.Count) policy file(s)" "Green"
+
+  $result = @{ Created = 0; Skipped = 0; Failed = 0 }
+
+  foreach ($file in $jsonFiles) {
+    $policyName = $file.BaseName
+    Write-Log "    Processing: $policyName" "Cyan"
+
+    # Check for existing policy with the same name
+    $existingPolicy = Get-MgBetaDeviceManagementConfigurationPolicy |
+      Where-Object { $_.Name -eq $policyName }
+
+    if ($existingPolicy) {
+      Write-Log "      Skipped - policy already exists." "Yellow"
+      $result.Skipped++
+      continue
+    }
+
+    try {
+      $jsonContent = Get-Content -Path $file.FullName -Raw -ErrorAction Stop
+      $newPolicy = New-MgBetaDeviceManagementConfigurationPolicy -BodyParameter $jsonContent -ErrorAction Stop
+      Write-Log "      Created successfully." "Green"
+      $result.Created++
+
+      # Assign to group if specified
+      if ($GroupId) {
+        try {
+          $assignBody = @{
+            assignments = @(
+              @{
+                target = @{
+                  "@odata.type" = "#microsoft.graph.groupAssignmentTarget"
+                  groupId       = $GroupId
+                }
+              }
+            )
+          } | ConvertTo-Json -Depth 10
+
+          Invoke-MgGraphRequest -Method POST `
+            -Uri "https://graph.microsoft.com/beta/deviceManagement/configurationPolicies/$($newPolicy.Id)/assign" `
+            -Body $assignBody -ContentType "application/json" -ErrorAction Stop
+
+          Write-Log "      Assigned to group $GroupId" "Green"
+        }
+        catch {
+          Write-Log "      WARNING: Created but failed to assign - $_" "Yellow"
+        }
+      }
+    }
+    catch {
+      Write-Log "      ERROR: Failed to create policy - $_" "Red"
+      $result.Failed++
+    }
+  }
+
+  return $result
+}
+
+# ── Step 3 - Deploy selected baselines ──────────────────────────────────────
+Write-Log "Step 3: Deploy selected baselines" "Cyan"
+
+$totals = @{ Created = 0; Skipped = 0; Failed = 0 }
+
+$baselines = @()
+if ($InstallWindows) {
+  $baselines += @{
+    Name = "Windows 11 v24H2"
+    Path = Join-Path $repoRoot "Windows Baseline 24H2"
+  }
+}
+if ($InstallEdge) {
+  $baselines += @{
+    Name = "Microsoft Edge v128"
+    Path = Join-Path $repoRoot "Edge Baseline"
+  }
+}
+if ($InstallM365) {
+  $baselines += @{
+    Name = "Microsoft 365 Apps"
+    Path = Join-Path $repoRoot "M365 Baseline"
+  }
+}
+
+foreach ($baseline in $baselines) {
+  $result = Deploy-BaselinePolicies -BaselineName $baseline.Name -JsonPath $baseline.Path -GroupId $GroupAssignmentId
+  $totals.Created += $result.Created
+  $totals.Skipped += $result.Skipped
+  $totals.Failed  += $result.Failed
+}
+
+# ── Step 4 - Cleanup ────────────────────────────────────────────────────────
+Write-Log ""
+Write-Log "Step 4: Cleanup temporary files" "Cyan"
+try {
+  Remove-Item -Path $tempFolder -Recurse -Force -ErrorAction Stop
+  Write-Log "  Temporary files removed." "Green"
+}
+catch {
+  Write-Log "  WARNING: Could not remove temp folder - $tempFolder" "Yellow"
+}
+
+# ── Summary ──────────────────────────────────────────────────────────────────
+Write-Host ""
+Write-Host "============================================================" -ForegroundColor Cyan
+Write-Host "  Deployment Summary                                        " -ForegroundColor Cyan
+Write-Host "============================================================" -ForegroundColor Cyan
+Write-Log "  Baselines deployed : $($selectedBaselines -join ', ')" "Cyan"
+Write-Log "  Policies created   : $($totals.Created)"  "Green"
+Write-Log "  Policies skipped   : $($totals.Skipped)"  "Yellow"
+if ($totals.Failed -gt 0) {
+  Write-Log "  Policies failed    : $($totals.Failed)"   "Red"
+}
+Write-Log "  Total processed    : $($totals.Created + $totals.Skipped + $totals.Failed)" "Cyan"
+if ($GroupAssignmentId) {
+  Write-Log "  Group assignment   : $GroupAssignmentId" "Cyan"
+}
+Write-Log "  Log file           : $logFilePath" "Cyan"
+Write-Host ""
+Write-Log "Deployment completed." "Green"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,126 @@
-Intune Security Baseline Json Configuration files
+# Intune Security Baselines
 
-## Winows Security Baseline
-***This will not include the LAPS category setting for the Backup Directory. This setting does not show in the Settings Catalog.***
+Intune Security Baseline JSON configuration files and automated deployment scripts for Microsoft Intune.
+
+## Available Baselines
+
+| Baseline | Policies | Directory |
+|---|---|---|
+| Windows 11 v24H2 | 28 | `Windows Baseline 24H2/` |
+| Microsoft Edge v128 | 7 | `Edge Baseline/` |
+| Microsoft 365 Apps | 12 | `M365 Baseline/` |
+
+> **Note:** The Windows Security Baseline does not include the LAPS category setting for Backup Directory. This setting does not appear in the Settings Catalog.
+
+## Quick Start
+
+Download and run the deployment script directly in PowerShell:
+
+```powershell
+irm "https://raw.githubusercontent.com/dgulle/Security-Baselines/master/Deploy-SecurityBaselines.ps1" -OutFile "$env:TEMP\Deploy-SecurityBaselines.ps1"; & "$env:TEMP\Deploy-SecurityBaselines.ps1" -InstallAll
+```
+
+## Deploy-SecurityBaselines.ps1
+
+Unified deployment script that downloads the baseline JSON files from this repository, creates the corresponding Intune device management configuration policies via Microsoft Graph, and cleans up temporary files automatically.
+
+### Prerequisites
+
+- PowerShell 5.1 or later
+- Internet access to download from GitHub and connect to Microsoft Graph
+- An Entra ID account with **Intune Administrator** or equivalent permissions
+- The `Microsoft.Graph.Beta` module (the script will install it automatically if missing)
+
+### Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `-InstallWindows` | Switch | Deploy Windows 11 v24H2 Security Baseline policies |
+| `-InstallEdge` | Switch | Deploy Microsoft Edge v128 Security Baseline policies |
+| `-InstallM365` | Switch | Deploy Microsoft 365 Apps Security Baseline policies |
+| `-InstallAll` | Switch | Deploy all available baselines (Windows, Edge, and M365) |
+| `-GroupAssignmentId` | String | Entra ID security group Object ID to assign all created policies to |
+
+### Usage Examples
+
+**Deploy all baselines:**
+
+```powershell
+.\Deploy-SecurityBaselines.ps1 -InstallAll
+```
+
+**Deploy only Windows and Edge baselines:**
+
+```powershell
+.\Deploy-SecurityBaselines.ps1 -InstallWindows -InstallEdge
+```
+
+**Deploy all baselines and assign to a security group:**
+
+```powershell
+.\Deploy-SecurityBaselines.ps1 -InstallAll -GroupAssignmentId "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+```
+
+**Deploy only M365 baselines with group assignment:**
+
+```powershell
+.\Deploy-SecurityBaselines.ps1 -InstallM365 -GroupAssignmentId "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+```
+
+### What the Script Does
+
+1. Displays selected baselines and prompts for confirmation
+2. Downloads and extracts the repository archive to a temporary folder
+3. Installs/imports the `Microsoft.Graph.Beta` module and authenticates to Microsoft Graph
+4. Creates Intune configuration policies from the JSON files (skips any that already exist by name)
+5. Optionally assigns each created policy to the specified Entra ID security group
+6. Cleans up all temporary files
+7. Displays a summary of created, skipped, and failed policies
+
+### Logs
+
+A log file is written to `%TEMP%\Deploy-SecurityBaselines.log` with timestamps for each operation.
+
+## Repository Structure
+
+```
+Security-Baselines/
+├── Deploy-SecurityBaselines.ps1                          # Unified deployment script
+├── Create-Windows-11-v24H2-Security-Baseline.ps1         # Windows-only deployment script
+├── GPO_Export_Template.xlsx
+├── README.md
+├── Windows Baseline 24H2/
+│   ├── Security Baseline 24H2 - Administrative Templates.json
+│   ├── Security Baseline 24H2 - Auditing.json
+│   ├── Security Baseline 24H2 - Browser.json
+│   ├── ...                                               # 28 policy JSON files
+│   └── UAT Form.xlsx
+├── Edge Baseline/
+│   ├── Edge Baseline - v128_Extensions.json
+│   ├── Edge Baseline - v128_Microsoft Edge.json
+│   ├── ...                                               # 7 policy JSON files
+│   └── Baseline Template and Script/                     # Export script (not for deployment)
+│       ├── MS_Edge_Baseline_Export.ps1
+│       └── Edge Baseline - v128.json
+└── M365 Baseline/
+    ├── Access.json
+    ├── Excel.json
+    ├── Outlook.json
+    ├── ...                                               # 12 policy JSON files
+    └── Baseline Template and Script/                     # Export script (not for deployment)
+        ├── M365 Baselines Export.ps1
+        └── M365 Baseline Template.json
+```
+
+## Export Scripts
+
+The `Baseline Template and Script/` subdirectories contain utility scripts for exporting new baselines from Intune. These are used to maintain and update the JSON files in this repository and are **not** part of the deployment process.
+
+- **MS_Edge_Baseline_Export.ps1** - Exports and splits Edge baseline policies by category
+- **M365 Baselines Export.ps1** - Exports and splits M365 baseline policies by application
+
+## Credits
+
+- [Dustin Gullett](https://www.linkedin.com/in/dustin-gullett-83607b1ba/) - Repository maintainer
+- [Thiago Beier](https://www.youracclaim.com/) - Deployment script author
+- Blog post: [Rolling Out Intune Security Baselines Without Causing a Workplace Uprising](https://zerototrust.tech/rolling-out-intune-security-baselines-without-causing-a-workplace-uprising/)


### PR DESCRIPTION
New unified deployment script that supports all three baselines:
- -InstallWindows, -InstallEdge, -InstallM365 switches (combinable)
- -InstallAll shorthand for deploying everything
- -GroupAssignmentId to assign created policies to an Entra ID group
- Auto-downloads repo archive to temp, deploys, and cleans up
- Includes Microsoft.Graph.Authentication version conflict fix
- Skips existing policies by name, logs all operations

README rewritten with quick start, parameter docs, usage examples, repository structure, and export script documentation.

https://claude.ai/code/session_01UmdPpxmbPP9TcWPHbm9zmE