### PR TITLE
Strip templateReference so all policies import as Settings Catalog

### DIFF
--- a/Deploy-SecurityBaselines.ps1
+++ b/Deploy-SecurityBaselines.ps1
@@ -263,6 +263,17 @@ function Deploy-BaselinePolicies {
 
     try {
       $jsonContent = Get-Content -Path $file.FullName -Raw -ErrorAction Stop
+
+      # Strip templateReference so policies are created as Settings Catalog, not Security Baselines
+      $jsonObject = $jsonContent | ConvertFrom-Json
+      $jsonObject.templateReference = @{
+        templateId             = ""
+        templateFamily         = "none"
+        templateDisplayName    = $null
+        templateDisplayVersion = $null
+      }
+      $jsonContent = $jsonObject | ConvertTo-Json -Depth 100
+
       $newPolicy = New-MgBetaDeviceManagementConfigurationPolicy -BodyParameter $jsonContent -ErrorAction Stop
       Write-Log "      Created successfully." "Green"
       $result.Created++


### PR DESCRIPTION
Edge and M365 JSON files contain templateReference with templateFamily=baseline, which causes Intune to create them as Security Baseline policies. The script now resets templateReference to empty/none before calling the Graph API, matching the behavior of manual JSON imports into Settings Catalog.

https://claude.ai/code/session_01UmdPpxmbPP9TcWPHbm9zmE