### PR TITLE
Update deployment script and README to reference 25H2 baselines

### DIFF
--- a/Deploy-SecurityBaselines.ps1
+++ b/Deploy-SecurityBaselines.ps1
@@ -4,14 +4,14 @@
 
 .DESCRIPTION
     Downloads the Security-Baselines repository from GitHub, extracts the selected
-    baseline JSON files (Windows 24H2, Edge v128, M365), and creates Intune device
+    baseline JSON files (Windows 25H2, Edge v128, M365), and creates Intune device
     management configuration policies for each one. Existing policies with the same
     name are skipped. Optionally assigns all created policies to an Entra ID security group.
 
     Temporary files are automatically cleaned up after deployment.
 
 .PARAMETER InstallWindows
-    Deploy Windows 11 v24H2 Security Baseline policies (28 policies).
+    Deploy Windows 11 v25H2 Security Baseline policies (28 policies).
 
 .PARAMETER InstallEdge
     Deploy Microsoft Edge v128 Security Baseline policies (7 policies).
@@ -108,7 +108,7 @@ Write-Host "============================================================" -Foreg
 Write-Host ""
 
 $selectedBaselines = @()
-if ($InstallWindows) { $selectedBaselines += "Windows 11 v24H2" }
+if ($InstallWindows) { $selectedBaselines += "Windows 11 v25H2" }
 if ($InstallEdge)    { $selectedBaselines += "Microsoft Edge v128" }
 if ($InstallM365)    { $selectedBaselines += "Microsoft 365 Apps" }
 
@@ -320,8 +320,8 @@ $totals = @{ Created = 0; Skipped = 0; Failed = 0 }
 $baselines = @()
 if ($InstallWindows) {
   $baselines += @{
-    Name = "Windows 11 v24H2"
-    Path = Join-Path $repoRoot "Windows Baseline 24H2"
+    Name = "Windows 11 v25H2"
+    Path = Join-Path $repoRoot "Windows Baseline 25H2"
   }
 }
 if ($InstallEdge) {

--- a/README.md
+++ b/README.md
@@ -6,11 +6,27 @@ Intune Security Baseline JSON configuration files and automated deployment scrip
 
 | Baseline | Policies | Directory |
 |---|---|---|
-| Windows 11 v24H2 | 28 | `Windows Baseline 24H2/` |
+| Windows 11 v25H2 | 28 | `Windows Baseline 25H2/` |
 | Microsoft Edge v128 | 7 | `Edge Baseline/` |
 | Microsoft 365 Apps | 12 | `M365 Baseline/` |
 
 > **Note:** The Windows Security Baseline does not include the LAPS category setting for Backup Directory. This setting does not appear in the Settings Catalog.
+
+## Settings Added in 25H2
+
+| Setting | Location | 25H2 Default | Notes |
+|---------|----------|-------------|-------|
+| Include command line in process creation events | Admin Templates > System > Audit Process Creation | Enabled | Captures full command-line args in Event ID 4688. Be aware that passwords passed via CLI will also be logged. |
+| Block process creations originating from PSExec and WMI commands | Defender > ASR Rules (under Allow Script Scanning) | Audit | GUID: `d1e49aac-8f56-4280-b9ba-993a6d77406c`. Audit-only to avoid breaking legitimate admin tooling. |
+| Impersonate Client - Windows restricted services (PrintSpoolerService) | User Rights > Impersonate Client | Added SID `S-1-5-99-216390572-1995538116-3857911515-2404958512-2623887229` | Supports Windows Protected Print (WPP). Removing this entry will break printing in WPP environments. SID may appear as raw value in Group Policy tools until service initializes. |
+
+## Settings Removed in 25H2
+
+| Setting | Location | 24H2 Default | Reason for Removal |
+|---------|----------|-------------|-------------------|
+| WDigest Authentication (disabling may require KB2871997) | Admin Templates > MS Security Guide | Disabled | Deprecated in 24H2. WDigest credential caching disabled by default since Windows 8.1. Existing registry values at `UseLogonCredential` will not auto-clean from prior deployments. |
+| Scan packed executables | Admin Templates > Microsoft Defender Antivirus > Scan | Enabled | No longer functional. Defender always scans packed executables by default now. |
+| Hide Exclusions From Local Users | Defender CSP | Enabled (hidden from local users) | Redundant. Parent setting "Hide Exclusions From Local Admins" (still present and enabled) takes precedence. |
 
 ## Quick Start
 
@@ -35,7 +51,7 @@ Unified deployment script that downloads the baseline JSON files from this repos
 
 | Parameter | Type | Description |
 |---|---|---|
-| `-InstallWindows` | Switch | Deploy Windows 11 v24H2 Security Baseline policies |
+| `-InstallWindows` | Switch | Deploy Windows 11 v25H2 Security Baseline policies |
 | `-InstallEdge` | Switch | Deploy Microsoft Edge v128 Security Baseline policies |
 | `-InstallM365` | Switch | Deploy Microsoft 365 Apps Security Baseline policies |
 | `-InstallAll` | Switch | Deploy all available baselines (Windows, Edge, and M365) |
@@ -86,13 +102,13 @@ A log file is written to `%TEMP%\Deploy-SecurityBaselines.log` with timestamps f
 ```
 Security-Baselines/
 ├── Deploy-SecurityBaselines.ps1                          # Unified deployment script
-├── Create-Windows-11-v24H2-Security-Baseline.ps1         # Windows-only deployment script
+├── Create-Windows-11-v25H2-Security-Baseline.ps1         # Windows-only deployment script
 ├── GPO_Export_Template.xlsx
 ├── README.md
-├── Windows Baseline 24H2/
-│   ├── Security Baseline 24H2 - Administrative Templates.json
-│   ├── Security Baseline 24H2 - Auditing.json
-│   ├── Security Baseline 24H2 - Browser.json
+├── Windows Baseline 25H2/
+│   ├── Security Baseline 25H2 - Administrative Templates.json
+│   ├── Security Baseline 25H2 - Auditing.json
+│   ├── Security Baseline 25H2 - Browser.json
 │   ├── ...                                               # 28 policy JSON files
 │   └── UAT Form.xlsx
 ├── Edge Baseline/


### PR DESCRIPTION
Switch all Windows baseline references from 24H2 to 25H2 in Deploy-SecurityBaselines.ps1 and README.md. Add changelog tables documenting settings added and removed in the 25H2 baseline.

https://claude.ai/code/session_01MQj9YBmw1ZXmoc7UsnqzbH